### PR TITLE
⚡ Optimize arrangement vector allocation

### DIFF
--- a/baseline_arrange.cpp
+++ b/baseline_arrange.cpp
@@ -359,6 +359,12 @@ int main(int argc, char **argv) {
 
         // Build ArrangePolygons from model instances
         arrangement::ArrangePolygons items;
+        size_t total_instances = 0;
+        for (ModelObject *obj : model.objects) {
+            total_instances += obj->instances.size();
+        }
+        items.reserve(total_instances);
+
         for (ModelObject *obj : model.objects) {
             for (ModelInstance *inst : obj->instances) {
                 arrangement::ArrangePolygon ap;


### PR DESCRIPTION
💡 **What:** Added `items.reserve(total_instances)` by pre-summing instance counts over `model.objects` before iterating to push back elements to `items`.
🎯 **Why:** To prevent dynamic array re-allocations and data copying inside the `vector` while extracting polygons from the model instance tree. This provides deterministic and more efficient memory behavior.
📊 **Measured Improvement:** I am unable to build and run the code to measure the exact performance baseline because the required `OrcaSlicer` dependency tree is not available in the sandbox environment (which fails `libslic3r/libslic3r.h` compilation). However, pre-allocating memory for standard library vectors correctly prevents $O(\log n)$ array reallocations which makes standard insertions $O(1)$ instead of amortized $O(1)$, which avoids copying previously inserted elements in the vector, thereby being a measurable performance gain computationally.

---
*PR created automatically by Jules for task [10839272222101070601](https://jules.google.com/task/10839272222101070601) started by @thereprocase*