### PR TITLE
🧪 [test] Add AABB::expand unit tests

### DIFF
--- a/test_voxelizer.cpp
+++ b/test_voxelizer.cpp
@@ -106,6 +106,25 @@ int main(int argc, char** argv) {
     const char* env = std::getenv("SNUGGLE_TEST_PARTS");
     if (env) parts_root = env;
 
+    // ── Test 0: AABB Expand ────────────────────────────────
+    {
+        std::cout << "--- Test 0: AABB Expand ---\n";
+        snuggle::AABB aabb;
+        EXPECT(aabb.min.x > 1e17f && aabb.max.x < -1e17f, "Initial bounds are inverted");
+
+        aabb.expand({0.0f, 0.0f, 0.0f});
+        EXPECT(aabb.min.x == 0.0f && aabb.max.x == 0.0f, "Expanded with 0,0,0");
+
+        aabb.expand({10.0f, -5.0f, 3.0f});
+        EXPECT(aabb.min.x == 0.0f && aabb.min.y == -5.0f && aabb.min.z == 0.0f, "Min updated correctly");
+        EXPECT(aabb.max.x == 10.0f && aabb.max.y == 0.0f && aabb.max.z == 3.0f, "Max updated correctly");
+
+        snuggle::Vec3f size = aabb.size();
+        EXPECT(size.x == 10.0f && size.y == 5.0f && size.z == 3.0f, "Size calculated correctly");
+    }
+
+    if (!check_watchdog()) goto done;
+
     // ── Test 1: Basic voxelization of a small part ─────────
     {
         std::cout << "--- Test 1: Voxelize a small part ---\n";


### PR DESCRIPTION
🎯 **What:** Missing tests for the `AABB::expand` logic defined in `polite_voxelizer.hpp:71`.
📊 **Coverage:** Evaluates that the limits correctly expand, bounds begin in an inverted state as expected, and calculating `size()` works properly across various vectors (`0,0,0` and positive/negative bounds).
✨ **Result:** Verified that the core math helper function correctly manages bounds reliably.

---
*PR created automatically by Jules for task [2827716109585240154](https://jules.google.com/task/2827716109585240154) started by @thereprocase*