### PR TITLE
Fix GL error clearing after glewInit

### DIFF
--- a/gpu_bench.cpp
+++ b/gpu_bench.cpp
@@ -175,7 +175,8 @@ int main() {
     GLFWwindow* win = glfwCreateWindow(1, 1, "", nullptr, nullptr);
     if (!win) { std::cerr << "GL 4.3 failed\n"; return 1; }
     glfwMakeContextCurrent(win);
-    glewExperimental = GL_TRUE; glewInit(); glGetError();
+    glewExperimental = GL_TRUE; glewInit();
+    while (glGetError() != GL_NO_ERROR) {}
     std::cout << "GPU: " << glGetString(GL_RENDERER) << "\n";
 
     GLuint program = compile_compute(BATCHED_SHADER);

--- a/gpu_poc.cpp
+++ b/gpu_poc.cpp
@@ -132,7 +132,7 @@ int main() {
         return 1;
     }
     // Clear the GL error from glewInit (known GLEW bug)
-    glGetError();
+    while (glGetError() != GL_NO_ERROR) {}
 
     std::cout << "  GL Vendor:   " << glGetString(GL_VENDOR) << "\n";
     std::cout << "  GL Renderer: " << glGetString(GL_RENDERER) << "\n";


### PR DESCRIPTION
Modified `gpu_poc.cpp` and `gpu_bench.cpp` to use a `while (glGetError() != GL_NO_ERROR) {}` loop to clear the OpenGL error queue after initializing GLEW, rather than a single `glGetError()` call. This ensures all errors from a known upstream GLEW bug are properly flushed.

---
*PR created automatically by Jules for task [11668879477360822039](https://jules.google.com/task/11668879477360822039) started by @thereprocase*