### PR TITLE
🧪 Add tests for SnuggleNester RNG helpers randf and randi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,3 +174,6 @@ target_link_libraries(test_voxelizer ${ORCA_LINK_LIBS})
 target_link_libraries(test_snuggle ${ORCA_LINK_LIBS})
 target_link_libraries(sweep_resolution ${ORCA_LINK_LIBS})
 target_link_libraries(sweep_full ${ORCA_LINK_LIBS})
+
+add_executable(test_rand test_rand.cpp nsvg_stub.cpp)
+target_link_libraries(test_rand ${ORCA_LINK_LIBS})

--- a/snuggle_nester.hpp
+++ b/snuggle_nester.hpp
@@ -283,6 +283,8 @@ public:
     }
 
 private:
+    friend class SnuggleNesterTest;
+
     NesterConfig cfg_;
     std::mt19937 rng_;
 

--- a/test_rand.cpp
+++ b/test_rand.cpp
@@ -1,0 +1,51 @@
+#include "snuggle_nester.hpp"
+#include <iostream>
+
+namespace snuggle {
+class SnuggleNesterTest {
+public:
+    static bool test_rand() {
+        NesterConfig cfg;
+        SnuggleNester nester(cfg, 42); // Seeded for determinism
+
+        float lo = -10.5f;
+        float hi = 20.5f;
+
+        bool passed = true;
+        for (int i = 0; i < 1000; i++) {
+            float val = nester.randf(lo, hi);
+            if (val < lo || val > hi) {
+                std::cout << "FAIL: randf returned " << val << " which is outside [" << lo << ", " << hi << "]\n";
+                passed = false;
+                break;
+            }
+        }
+
+        if (passed) {
+            std::cout << "PASS: randf generated 1000 values correctly within bounds\n";
+        }
+
+        size_t int_lo = 5;
+        size_t int_hi = 15;
+        for (int i = 0; i < 1000; i++) {
+            size_t val = nester.randi(int_lo, int_hi);
+            if (val < int_lo || val > int_hi) {
+                std::cout << "FAIL: randi returned " << val << " which is outside [" << int_lo << ", " << int_hi << "]\n";
+                passed = false;
+                break;
+            }
+        }
+
+        if (passed) {
+            std::cout << "PASS: randi generated 1000 values correctly within bounds\n";
+        }
+
+        return passed;
+    }
+};
+}
+
+int main() {
+    bool passed = snuggle::SnuggleNesterTest::test_rand();
+    return passed ? 0 : 1;
+}


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the private random number generator functions `randf` and `randi` in `snuggle_nester.hpp`.

📊 **Coverage:** Added a dedicated standalone test file `test_rand.cpp` that spins up `SnuggleNester` with a seeded RNG and runs 1000 generation iterations on both floating point (`randf`) and integer (`randi`) helper functions. Verified outputs strictly fall inside expected minimum and maximum bounds. The tests are configured properly as a new CMake execution target. To keep correct class encapsulation, the functions remained private and a `friend class SnuggleNesterTest` was added.

✨ **Result:** Test coverage improved. Random distribution logic can now be refactored safely, with deterministic tests acting as regression safeguards.

---
*PR created automatically by Jules for task [1868141103932350754](https://jules.google.com/task/1868141103932350754) started by @thereprocase*