### PR TITLE
🧹 Refactor: Consolidate Mesh Extraction Logic into snuggle::RawMesh

### DIFF
--- a/polite_voxelizer.hpp
+++ b/polite_voxelizer.hpp
@@ -80,6 +80,48 @@ struct Triangle {
     Vec3f v0, v1, v2;
 };
 
+// ── RawMesh: extracted flat mesh for voxelization ─────────
+struct RawMesh {
+    std::vector<float>    vertices;
+    std::vector<uint32_t> indices;
+    size_t num_verts = 0;
+    size_t num_tris = 0;
+
+    template <typename TriangleMeshType>
+    static RawMesh extract(const TriangleMeshType &mesh) {
+        RawMesh m;
+        const auto &its = mesh.its;
+        m.num_verts = its.vertices.size();
+        m.num_tris = its.indices.size();
+
+        m.vertices.resize(m.num_verts * 3);
+        m.indices.resize(m.num_tris * 3);
+
+        if constexpr (sizeof(its.vertices[0]) == 3 * sizeof(float) && sizeof(its.indices[0]) == 3 * sizeof(uint32_t)) {
+            if (m.num_verts > 0) {
+                std::memcpy(m.vertices.data(), its.vertices.data(), m.num_verts * 3 * sizeof(float));
+            }
+            if (m.num_tris > 0) {
+                std::memcpy(m.indices.data(), its.indices.data(), m.num_tris * 3 * sizeof(uint32_t));
+            }
+        } else {
+            for (size_t i = 0; i < m.num_verts; i++) {
+                m.vertices[i*3+0] = its.vertices[i].x();
+                m.vertices[i*3+1] = its.vertices[i].y();
+                m.vertices[i*3+2] = its.vertices[i].z();
+                if ((i+1) % 5000 == 0) polite_yield();
+            }
+            for (size_t i = 0; i < m.num_tris; i++) {
+                m.indices[i*3+0] = its.indices[i](0);
+                m.indices[i*3+1] = its.indices[i](1);
+                m.indices[i*3+2] = its.indices[i](2);
+            }
+        }
+
+        return m;
+    }
+};
+
 // ── Error codes ───────────────────────────────────────────
 enum class VoxError {
     OK = 0,

--- a/sweep_full.cpp
+++ b/sweep_full.cpp
@@ -38,31 +38,7 @@ bool watchdog_ok() {
     return true;
 }
 
-struct RawMesh {
-    std::vector<float> verts;
-    std::vector<uint32_t> indices;
-    size_t nv = 0, nt = 0;
-};
 
-RawMesh extract(const TriangleMesh &mesh) {
-    RawMesh m;
-    const auto &its = mesh.its;
-    m.nv = its.vertices.size();
-    m.nt = its.indices.size();
-    m.verts.resize(m.nv * 3);
-    m.indices.resize(m.nt * 3);
-    for (size_t i = 0; i < m.nv; i++) {
-        m.verts[i*3] = its.vertices[i].x();
-        m.verts[i*3+1] = its.vertices[i].y();
-        m.verts[i*3+2] = its.vertices[i].z();
-    }
-    for (size_t i = 0; i < m.nt; i++) {
-        m.indices[i*3] = its.indices[i](0);
-        m.indices[i*3+1] = its.indices[i](1);
-        m.indices[i*3+2] = its.indices[i](2);
-    }
-    return m;
-}
 
 float bounding_area(const std::vector<snuggle::Placement> &pl,
                     const std::vector<snuggle::PartInfo> &parts) {
@@ -153,7 +129,7 @@ int main(int argc, char** argv) {
         if (!watchdog_ok()) break;
 
         // Load meshes once per test
-        std::vector<RawMesh> meshes;
+        std::vector<snuggle::RawMesh> meshes;
         std::vector<std::string> names;
         bool load_ok = true;
 
@@ -164,7 +140,7 @@ int main(int argc, char** argv) {
                 std::cout << ts.name << ": LOAD FAILED " << fname << "\n";
                 load_ok = false; break;
             }
-            meshes.push_back(extract(model.objects[0]->volumes[0]->mesh()));
+            meshes.push_back(snuggle::RawMesh::extract(model.objects[0]->volumes[0]->mesh()));
             names.push_back(fname);
         }
         if (!load_ok) continue;
@@ -181,8 +157,8 @@ int main(int argc, char** argv) {
                 snuggle::PartInfo pi;
                 pi.name = names[mi];
                 auto err = snuggle::voxelize_indexed_mesh(
-                    meshes[mi].verts.data(), meshes[mi].nv,
-                    meshes[mi].indices.data(), meshes[mi].nt,
+                    meshes[mi].vertices.data(), meshes[mi].num_verts,
+                    meshes[mi].indices.data(), meshes[mi].num_tris,
                     vs, pi.grid);
                 if (err != snuggle::VoxError::OK) {
                     std::cout << ts.name << " @ " << vs << "mm: vox fail " << names[mi] << "\n";

--- a/sweep_resolution.cpp
+++ b/sweep_resolution.cpp
@@ -22,31 +22,7 @@ namespace stdfs = std::filesystem;
 using namespace Slic3r;
 using Clock = std::chrono::steady_clock;
 
-struct RawMesh {
-    std::vector<float> verts;
-    std::vector<uint32_t> indices;
-    size_t nv = 0, nt = 0;
-};
 
-RawMesh extract(const TriangleMesh &mesh) {
-    RawMesh m;
-    const auto &its = mesh.its;
-    m.nv = its.vertices.size();
-    m.nt = its.indices.size();
-    m.verts.resize(m.nv * 3);
-    m.indices.resize(m.nt * 3);
-    for (size_t i = 0; i < m.nv; i++) {
-        m.verts[i*3] = its.vertices[i].x();
-        m.verts[i*3+1] = its.vertices[i].y();
-        m.verts[i*3+2] = its.vertices[i].z();
-    }
-    for (size_t i = 0; i < m.nt; i++) {
-        m.indices[i*3] = its.indices[i](0);
-        m.indices[i*3+1] = its.indices[i](1);
-        m.indices[i*3+2] = its.indices[i](2);
-    }
-    return m;
-}
 
 float bounding_area(const std::vector<snuggle::Placement> &pl,
                     const std::vector<snuggle::PartInfo> &parts) {
@@ -130,13 +106,13 @@ int main(int argc, char** argv) {
         std::cout << "==============================\n\n";
 
         // Load raw meshes
-        std::vector<RawMesh> meshes;
+        std::vector<snuggle::RawMesh> meshes;
         std::vector<std::string> names;
         for (const auto &path : ts.paths) {
             Model model;
             std::string fname = stdfs::path(path).filename().string();
             load_stl(path.c_str(), &model, fname.c_str());
-            meshes.push_back(extract(model.objects[0]->volumes[0]->mesh()));
+            meshes.push_back(snuggle::RawMesh::extract(model.objects[0]->volumes[0]->mesh()));
             names.push_back(fname);
         }
 
@@ -156,8 +132,8 @@ int main(int argc, char** argv) {
                 snuggle::PartInfo pi;
                 pi.name = names[mi];
                 auto err = snuggle::voxelize_indexed_mesh(
-                    meshes[mi].verts.data(), meshes[mi].nv,
-                    meshes[mi].indices.data(), meshes[mi].nt,
+                    meshes[mi].vertices.data(), meshes[mi].num_verts,
+                    meshes[mi].indices.data(), meshes[mi].num_tris,
                     vs, pi.grid);
                 if (err != snuggle::VoxError::OK) {
                     std::cout << vs << "mm: voxelization failed for " << names[mi]

--- a/test_snuggle.cpp
+++ b/test_snuggle.cpp
@@ -31,31 +31,7 @@ static constexpr float BED_W          = 256.0f;
 static constexpr float BED_H          = 256.0f;
 
 // ── Extract mesh data from Orca ───────────────────────────
-struct RawMesh {
-    std::vector<float>    verts;
-    std::vector<uint32_t> indices;
-    size_t nv = 0, nt = 0;
-};
 
-RawMesh extract(const TriangleMesh &mesh) {
-    RawMesh m;
-    const auto &its = mesh.its;
-    m.nv = its.vertices.size();
-    m.nt = its.indices.size();
-    m.verts.resize(m.nv * 3);
-    m.indices.resize(m.nt * 3);
-    for (size_t i = 0; i < m.nv; i++) {
-        m.verts[i*3+0] = its.vertices[i].x();
-        m.verts[i*3+1] = its.vertices[i].y();
-        m.verts[i*3+2] = its.vertices[i].z();
-    }
-    for (size_t i = 0; i < m.nt; i++) {
-        m.indices[i*3+0] = its.indices[i](0);
-        m.indices[i*3+1] = its.indices[i](1);
-        m.indices[i*3+2] = its.indices[i](2);
-    }
-    return m;
-}
 
 // ── Compute packing bounding area ─────────────────────────
 float bounding_area(const std::vector<snuggle::Placement> &pl,
@@ -169,15 +145,15 @@ int main(int argc, char** argv) {
                 std::cout << "FAILED\n"; ok = false; break;
             }
 
-            RawMesh rm = extract(model.objects[0]->volumes[0]->mesh());
+            snuggle::RawMesh rm = snuggle::RawMesh::extract(model.objects[0]->volumes[0]->mesh());
 
             snuggle::PartInfo pi;
             pi.name = fname;
 
             auto t0 = Clock::now();
             auto err = snuggle::voxelize_indexed_mesh(
-                rm.verts.data(), rm.nv,
-                rm.indices.data(), rm.nt,
+                rm.vertices.data(), rm.num_verts,
+                rm.indices.data(), rm.num_tris,
                 VOXEL_SIZE_MM, pi.grid);
             auto t1 = Clock::now();
             double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
@@ -192,7 +168,7 @@ int main(int argc, char** argv) {
             pi.max_height_mm = pi.grid.nz * pi.grid.voxel_size;
             pi.hull_area_mm2 = pi.grid.nx * pi.grid.ny * pi.grid.voxel_size * pi.grid.voxel_size;
 
-            std::cout << rm.nt << " tris -> "
+            std::cout << rm.num_tris << " tris -> "
                       << pi.grid.nx << "x" << pi.grid.ny << "x" << pi.grid.nz
                       << " (" << ms << "ms)\n";
 

--- a/test_voxelizer.cpp
+++ b/test_voxelizer.cpp
@@ -46,36 +46,7 @@ bool check_watchdog() {
 
 // ── Extract triangles from Orca TriangleMesh ──────────────
 //    Copies into snuggle's format. Polite: yields during copy.
-struct MeshData {
-    std::vector<float>    vertices;  // flat xyz
-    std::vector<uint32_t> indices;   // flat i0,i1,i2
-    size_t num_tris = 0;
-    size_t num_verts = 0;
-};
 
-MeshData extract_mesh(const TriangleMesh &mesh) {
-    MeshData md;
-    const auto &its = mesh.its;
-    md.num_verts = its.vertices.size();
-    md.num_tris = its.indices.size();
-
-    md.vertices.resize(md.num_verts * 3);
-    for (size_t i = 0; i < md.num_verts; i++) {
-        md.vertices[i*3+0] = its.vertices[i].x();
-        md.vertices[i*3+1] = its.vertices[i].y();
-        md.vertices[i*3+2] = its.vertices[i].z();
-        if ((i+1) % 5000 == 0) snuggle::polite_yield();
-    }
-
-    md.indices.resize(md.num_tris * 3);
-    for (size_t i = 0; i < md.num_tris; i++) {
-        md.indices[i*3+0] = its.indices[i](0);
-        md.indices[i*3+1] = its.indices[i](1);
-        md.indices[i*3+2] = its.indices[i](2);
-    }
-
-    return md;
-}
 
 // ── Test result tracking ──────────────────────────────────
 static int g_pass = 0, g_fail = 0;
@@ -115,7 +86,7 @@ int main(int argc, char** argv) {
         EXPECT(loaded, "STL loaded");
         if (!loaded) goto done;
 
-        MeshData md = extract_mesh(model.objects[0]->volumes[0]->mesh());
+        snuggle::RawMesh md = snuggle::RawMesh::extract(model.objects[0]->volumes[0]->mesh());
         std::cout << "  Mesh: " << md.num_tris << " tris, " << md.num_verts << " verts\n";
 
         snuggle::VoxelGrid grid;
@@ -155,7 +126,7 @@ int main(int argc, char** argv) {
         Model model;
         std::string path = parts_root + "/small/part2.stl";
         load_stl(path.c_str(), &model, "cap");
-        MeshData md = extract_mesh(model.objects[0]->volumes[0]->mesh());
+        snuggle::RawMesh md = snuggle::RawMesh::extract(model.objects[0]->volumes[0]->mesh());
 
         snuggle::VoxelGrid gridA, gridB;
         snuggle::voxelize_indexed_mesh(
@@ -183,7 +154,7 @@ int main(int argc, char** argv) {
         Model model;
         std::string path = parts_root + "/small/part2.stl";
         load_stl(path.c_str(), &model, "cap");
-        MeshData md = extract_mesh(model.objects[0]->volumes[0]->mesh());
+        snuggle::RawMesh md = snuggle::RawMesh::extract(model.objects[0]->volumes[0]->mesh());
 
         snuggle::VoxelGrid gridA, gridB;
         snuggle::voxelize_indexed_mesh(
@@ -214,7 +185,7 @@ int main(int argc, char** argv) {
         EXPECT(loaded, "Large STL loaded");
         if (!loaded) goto done;
 
-        MeshData md = extract_mesh(model.objects[0]->volumes[0]->mesh());
+        snuggle::RawMesh md = snuggle::RawMesh::extract(model.objects[0]->volumes[0]->mesh());
         std::cout << "  Mesh: " << md.num_tris << " tris\n";
 
         snuggle::VoxelGrid grid;
@@ -253,8 +224,8 @@ int main(int argc, char** argv) {
         load_stl((parts_root + "/small/part2.stl").c_str(), &modelA, "cap");
         load_stl((parts_root + "/small/part3.stl").c_str(), &modelB, "case");
 
-        MeshData mdA = extract_mesh(modelA.objects[0]->volumes[0]->mesh());
-        MeshData mdB = extract_mesh(modelB.objects[0]->volumes[0]->mesh());
+        snuggle::RawMesh mdA = snuggle::RawMesh::extract(modelA.objects[0]->volumes[0]->mesh());
+        snuggle::RawMesh mdB = snuggle::RawMesh::extract(modelB.objects[0]->volumes[0]->mesh());
 
         snuggle::VoxelGrid gridA, gridB;
         snuggle::voxelize_indexed_mesh(mdA.vertices.data(), mdA.num_verts,
@@ -297,7 +268,7 @@ int main(int argc, char** argv) {
         std::cout << "\n--- Test 6: Memory guard (try insane resolution) ---\n";
         Model model;
         load_stl((parts_root + "/small/part2.stl").c_str(), &model, "cap");
-        MeshData md = extract_mesh(model.objects[0]->volumes[0]->mesh());
+        snuggle::RawMesh md = snuggle::RawMesh::extract(model.objects[0]->volumes[0]->mesh());
 
         snuggle::VoxelGrid grid;
         // 0.01mm resolution on a 30mm part = 3000^3 grid = WAY too big


### PR DESCRIPTION
🎯 **What:** Extracted duplicate `MeshData` and `RawMesh` struct definitions and their respective `extract_mesh` / `extract` methods from multiple standalone execution scripts (`test_voxelizer.cpp`, `test_snuggle.cpp`, `sweep_full.cpp`, and `sweep_resolution.cpp`) into a unified `snuggle::RawMesh` struct located in `polite_voxelizer.hpp`.

💡 **Why:** This resolves duplicated code logic mapping OrcaSlicer's `TriangleMesh` data into snuggle's internal representation, making the overall algorithm logic easier to read and maintain. An added performance boost was implemented inside the unified `extract` logic that bypasses safe per-vertex loops via `std::memcpy` if the underlying arrays match standard struct packing natively.

✅ **Verification:** A standalone test was successfully executed to ensure `extract` works correctly by compiling `polite_voxelizer.hpp` using isolated mock structs mimicking the OrcaSlicer interface. Furthermore, string replacements successfully addressed all remaining instances of the refactored code components in the codebase.

✨ **Result:** Cleaned codebase, eliminated copy-paste overhead, and optimized data conversion speed!

---
*PR created automatically by Jules for task [13779926849012030421](https://jules.google.com/task/13779926849012030421) started by @thereprocase*