### PR TITLE
perf: share triangle AABB between grid-bounds and SAT test

### DIFF
--- a/polite_voxelizer.hpp
+++ b/polite_voxelizer.hpp
@@ -364,19 +364,21 @@ inline VoxError voxelize_mesh(
     for (size_t ti = 0; ti < num_triangles; ti++) {
         const Triangle &tri = triangles[ti];
 
-        // Triangle AABB in grid coords (conservative: floor min, ceil max)
+        // Triangle AABB in world coords — shared with the per-voxel SAT test below.
+        float tri_min_x = std::min({tri.v0.x, tri.v1.x, tri.v2.x});
+        float tri_max_x = std::max({tri.v0.x, tri.v1.x, tri.v2.x});
+        float tri_min_y = std::min({tri.v0.y, tri.v1.y, tri.v2.y});
+        float tri_max_y = std::max({tri.v0.y, tri.v1.y, tri.v2.y});
+        float tri_min_z = std::min({tri.v0.z, tri.v1.z, tri.v2.z});
+        float tri_max_z = std::max({tri.v0.z, tri.v1.z, tri.v2.z});
+
+        // Triangle AABB in grid coords (conservative: floor min, ceil max).
+        // world_to_grid is componentwise affine, so the grid AABB of the
+        // vertex set equals the grid transform of the world AABB corners —
+        // two world_to_grid calls instead of three.
         int ix_min, iy_min, iz_min, ix_max, iy_max, iz_max;
-        out_grid.world_to_grid(tri.v0, ix_min, iy_min, iz_min);
-        ix_max = ix_min; iy_max = iy_min; iz_max = iz_min;
-
-        int tx, ty, tz;
-        out_grid.world_to_grid(tri.v1, tx, ty, tz);
-        ix_min = std::min(ix_min, tx); iy_min = std::min(iy_min, ty); iz_min = std::min(iz_min, tz);
-        ix_max = std::max(ix_max, tx); iy_max = std::max(iy_max, ty); iz_max = std::max(iz_max, tz);
-
-        out_grid.world_to_grid(tri.v2, tx, ty, tz);
-        ix_min = std::min(ix_min, tx); iy_min = std::min(iy_min, ty); iz_min = std::min(iz_min, tz);
-        ix_max = std::max(ix_max, tx); iy_max = std::max(iy_max, ty); iz_max = std::max(iz_max, tz);
+        out_grid.world_to_grid({tri_min_x, tri_min_y, tri_min_z}, ix_min, iy_min, iz_min);
+        out_grid.world_to_grid({tri_max_x, tri_max_y, tri_max_z}, ix_max, iy_max, iz_max);
 
         // Expand by 1 in each direction (conservative outward)
         ix_min = std::max(0, ix_min - 1);
@@ -414,14 +416,6 @@ inline VoxError voxelize_mesh(
         Vec3f n = e0.cross(e1);
         float n_r = half.x * std::abs(n.x) + half.y * std::abs(n.y) + half.z * std::abs(n.z);
         float n_tri_dot = n.dot(tri.v0); // constant since n.dot(v0) == n.dot(v1) == n.dot(v2)
-
-        // Precompute bounds for the 3 box face axes
-        float tri_min_x = std::min({tri.v0.x, tri.v1.x, tri.v2.x});
-        float tri_max_x = std::max({tri.v0.x, tri.v1.x, tri.v2.x});
-        float tri_min_y = std::min({tri.v0.y, tri.v1.y, tri.v2.y});
-        float tri_max_y = std::max({tri.v0.y, tri.v1.y, tri.v2.y});
-        float tri_min_z = std::min({tri.v0.z, tri.v1.z, tri.v2.z});
-        float tri_max_z = std::max({tri.v0.z, tri.v1.z, tri.v2.z});
 
         // For the 9 cross-product axes, precompute the bounds of the triangle projected onto the axis
         float ax_tri_min[9];


### PR DESCRIPTION
## Summary

Alternate to #23 and #24 for the voxelizer Phase-2 triangle-AABB work.

Post-#20, Phase 2 computes the triangle's per-axis min/max **twice**:
1. Implicitly by calling \`world_to_grid\` on all three vertices and reducing componentwise.
2. Explicitly as \`tri_min_x\`/\`tri_max_x\` floats, which the per-voxel SAT test uses for box-face rejection.

Compute once, share. \`world_to_grid\` is componentwise affine, so the grid AABB of a vertex set equals \`world_to_grid\` applied to the two corners of the world AABB.

**Result:** one fewer \`world_to_grid\` call per triangle, deduplicated min/max work, net -6 lines.

## Why not #23 as-is

#23 allocated a persistent \`std::vector<AABB>(num_triangles)\` as the caching mechanism. For a 5M-triangle mesh that's ~120 MB of extra allocation to save ~5% of the rasterization time. Inline sharing between the two sites that already needed the same values gets the same speedup for zero memory.

## Why not #24 as-is

#24 also refactors \`triangle_aabb_overlap\`'s SAT test ordering. That's a fine idea in isolation, but \`voxelize_mesh\` no longer calls \`triangle_aabb_overlap\` after PR #20 inlined the SAT checks into the per-voxel loop with precomputed per-axis constants. Modifying \`triangle_aabb_overlap\` now only affects \`test_sat\`'s exercise of it, not production rasterization. That reorg can land separately if someone wants to apply the same cheap-reject-first discipline to the inlined loop.

## Correctness argument

\`world_to_grid\` is \`(p - origin) / voxel_size\` componentwise. For a componentwise monotone affine transform, the min of \`f(v_i).x\` over a set of vectors equals \`f(v_with_min_x).x\`. So transforming the world AABB corners and taking min/max of the results is identical to transforming every vertex and reducing.

## Test plan
- [ ] Build and run \`test_voxelizer\` — rasterization should be bitwise identical to pre-change output on any input.
- [ ] \`test_sat\` should remain unaffected (\`triangle_aabb_overlap\` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)